### PR TITLE
Fix: Use root user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`0.1.0...master`](https://github.com/localheinz/composer-normalize-action/compare/0.1.0...master).
 
+### Fixed
+
+* Switched to using the `root` user in `Dockerfile` to allow access to the GitHub workspace ([#6](https://github.com/localheinz/composer-normalize-action/pull/6)), by [@localheinz](https://github.com/localheinz)
+
 ## [`0.1.0`](https://github.com/localheinz/composer-normalize-action/releases/tag/0.1.0)
 
 For a full diff see [`afa2393...0.1.0`](https://github.com/localheinz/composer-normalize-action/compare/afa2393...0.1.0).

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,9 @@ LABEL "maintainer"="Andreas Möller <am@localheinz.com>"
 
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-RUN addgroup -g 1000 -S normalizer && adduser -u 1000 -S normalizer -G normalizer
+ENV COMPOSER_ALLOW_SUPERUSER=1
 
-USER normalizer
-
-RUN mkdir /home/normalizer/.composer && chown -R normalizer:normalizer /home/normalizer/.composer
-
-COPY --chown=normalizer composer.* /home/normalizer/.composer/
+COPY composer.* /root/.composer/
 
 RUN composer global install
 


### PR DESCRIPTION
This PR

* [x] uses the `root` user instead of creating and using a different user

💁‍♂ For reference, see https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#environment-variables.