### PR TITLE
Fix: Copy global composer directory into GitHub home directory

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,12 +1,6 @@
 #!/bin/sh -l
 
-sh -c "whoami"
-sh -c "echo $HOME"
-sh -c "ls -la $HOME"
-sh -c "ls -la /root"
-sh -c "echo $COMPOSER_HOME"
-sh -c "which composer"
+sh -c "if [[ '$HOME' != '/root' ]]; then cp -r /root/.composer $HOME/.composer; fi"
 sh -c "/usr/local/bin/composer global show --direct"
 sh -c "/usr/local/bin/composer list"
-sh -c "ls -la"
 sh -c "/usr/local/bin/composer normalize --dry-run"


### PR DESCRIPTION
This PR

* [x] copies the global `.composer` directory into GitHub home directory