### PR TITLE
Fix: Remove remaining debug output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,4 @@
 #!/bin/sh -l
 
 sh -c "if [[ '$HOME' != '/root' ]]; then cp -r /root/.composer $HOME/.composer; fi"
-sh -c "/usr/local/bin/composer global show --direct"
-sh -c "/usr/local/bin/composer list"
 sh -c "/usr/local/bin/composer normalize --dry-run"


### PR DESCRIPTION
This PR

* [x] removes rendering of debug output