### PR TITLE
Fix: Invoke composer without absolute path

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh -l
 
 sh -c "if [[ '$HOME' != '/root' ]]; then cp -r /root/.composer $HOME/.composer; fi"
-sh -c "/usr/local/bin/composer normalize --dry-run"
+sh -c "composer normalize --dry-run"


### PR DESCRIPTION
This PR

* [x] invokes `composer` without absolute path