### PR TITLE
Enhancement: Allow specifying the version of localheinz/composer-normalize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,9 @@ LABEL "maintainer"="Andreas Möller <am@localheinz.com>"
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 ENV COMPOSER_ALLOW_SUPERUSER=1
+ENV COMPOSER_NORMALIZE_VERSION=1.3.0
 
-RUN composer global require localheinz/composer-normalize:1.3.0
+RUN composer global require localheinz/composer-normalize:$COMPOSER_NORMALIZE_VERSION
 
 ADD entrypoint.sh /entrypoint.sh
 

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,14 @@ description: 'Ensure your PHP project has a normalized composer.json.'
 
 author: Andreas Möller
 
+inputs:
+  composer-normalize-version:
+    description: 'The version of localheinz/composer-normalize you wish to use.'
+    required: false
+    default: '1.3.0'
+
 runs:
   using: 'docker'
   image: 'docker://localheinz/composer-normalize-action'
+  env:
+    - COMPOSER_NORMALIZE_VERSION: '${{ inputs.composer-normalize-version }}'


### PR DESCRIPTION
This PR

* [x] hopefully allows specifying the version of `localheinz/composer-normalize` that should be used

💁‍♂ For reference, see https://help.github.com/en/articles/metadata-syntax-for-github-actions.