### PR TITLE
Fix: Use GitHub handle as value for author

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ branding:
 
 description: 'Ensure your PHP project has a normalized composer.json.'
 
-author: Andreas Möller
+author: 'localheinz'
 
 runs:
   using: 'docker'


### PR DESCRIPTION
This PR

* [x] uses my GitHub handle as value for `author`

🤷‍♂ Is that what it should be?