### PR TITLE
Fix: Use old name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 # https://help.github.com/en/articles/metadata-syntax-for-github-actions
 
-name: 'composer-normalize-action'
+name: 'localheinz/composer-normalize-action'
 
 branding:
   icon: 'box'


### PR DESCRIPTION
This PR

* [x] switches back to using the old name