### PR TITLE
Fix: Use new name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 # https://help.github.com/en/articles/metadata-syntax-for-github-actions
 
-name: 'localheinz/composer-normalize-action'
+name: 'composer-normalize-action'
 
 branding:
   icon: 'box'


### PR DESCRIPTION
This PR

* [x] uses the new name again

🤷‍♂ Seems like I can't put the action back on the marketplace with the old name.

![Screen Shot 2019-08-22 at 21 28 35](https://user-images.githubusercontent.com/605483/63544246-00d60a80-c525-11e9-9d2c-363c24182289.png)
