### PR TITLE
Fix: Use environment variable directly and require localheinz/composer-normalize in entrypoint.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+For a full diff see [`0.4.1...master`](https://github.com/localheinz/composer-normalize-action/compare/0.4.1...master).
+
+## [`0.4.1`](https://github.com/localheinz/composer-normalize-action/releases/tag/0.4.1)
+
+For a full diff see [`0.4.0...0.4.1`](https://github.com/localheinz/composer-normalize-action/compare/0.4.0...0.4.1).
+
+### Fixed
+
+* Use environment variable `COMPOSER_NORMALIZE_VERSION` directly instead of input parameter `composer-normalize-version` and require corresponding version of `localheinz/composer-normalize` in `entrypoint.sh` ([#35](https://github.com/localheinz/composer-normalize-action/pull/35)), by [@localheinz](https://github.com/localheinz)
+
 For a full diff see [`0.4.0...master`](https://github.com/localheinz/composer-normalize-action/compare/0.4.0...master).
 
 ## [`0.4.0`](https://github.com/localheinz/composer-normalize-action/releases/tag/0.4.0)

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ jobs:
         uses: docker://localheinz/composer-normalize-action:x.y.z
 ```
 
-### Inputs
+### Environment Variables
 
-If you wish to specify the version of [`localheinz/composer-normalize`](https://github.com/localheinz/composer-normalize)  that should be used by the action, you can use the `composer-normalize-version` input parameter:
+If you wish to specify the version of [`localheinz/composer-normalize`](https://github.com/localheinz/composer-normalize)  that should be used by the action, you can use the `COMPOSER_NORMALIZE_VERSION` environment variable:
 
 ```yaml
 name: CI
@@ -61,8 +61,8 @@ jobs:
       - uses: actions/checkout@master
       - name: Run localheinz/composer-normalize
         uses: docker://localheinz/composer-normalize-action
-        with:
-          composer-normalize-version: '^1.3.0'
+        env:
+          COMPOSER_NORMALIZE_VERSION: '^1.3.0'
 ```
 
 The value can be a range (for example, `^1.3.0`) or an exact version (for example, `1.2.0`).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh -l
 
+sh -c "composer global require localheinz/composer-normalize:$COMPOSER_NORMALIZE_VERSION"
 sh -c "if [[ '$HOME' != '/root' ]]; then cp -r /root/.composer $HOME/.composer; fi"
 sh -c "composer normalize --dry-run"


### PR DESCRIPTION
This PR

* [x] uses the environment variable `COMPOSER_NORMALIZE_VERSION` directly (instead of the previously added input parameter `composer-normalize-version` and requires `localheinz/composer-normalize` in the specified version in `entrypoint.sh`