### PR TITLE
Enhancement: Require localheinz/composer-normalize only when different from default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`0.4.2...master`](https://github.com/localheinz/composer-no
 ### Changed
 
 * Started using `php:7.3-cli-alpine` instead of `php:7.3-alpine` as Docker base image ([#39](https://github.com/localheinz/composer-normalize-action/pull/39)), by [@localheinz](https://github.com/localheinz)
+* Requiring `localheinz/composer-normalize` only when value of `COMPOSER_NORMALIZE_VERSION` environment variable is different from initially installed version ([#40](https://github.com/localheinz/composer-normalize-action/pull/40)), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.4.2`](https://github.com/localheinz/composer-normalize-action/releases/tag/0.4.2)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ LABEL "maintainer"="Andreas Möller <am@localheinz.com>"
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 ENV COMPOSER_ALLOW_SUPERUSER=1
-ENV COMPOSER_NORMALIZE_VERSION=1.3.0
+ENV COMPOSER_NORMALIZE_VERSION_DEFAULT=1.3.0
 
-RUN composer global require localheinz/composer-normalize:$COMPOSER_NORMALIZE_VERSION
+RUN composer global require localheinz/composer-normalize:$COMPOSER_NORMALIZE_VERSION_DEFAULT
 
 ADD entrypoint.sh /entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -l
 
-sh -c "composer global require localheinz/composer-normalize:$COMPOSER_NORMALIZE_VERSION"
+sh -c "if [[ ! -z $COMPOSER_NORMALIZE_VERSION && '$COMPOSER_NORMALIZE_VERSION' != '$COMPOSER_NORMALIZE_VERSION_DEFAULT' ]]; then composer global require localheinz/composer-normalize:$COMPOSER_NORMALIZE_VERSION; fi"
 sh -c "if [[ '$HOME' != '/root' ]]; then cp -r /root/.composer $HOME/.composer; fi"
 sh -c "composer normalize --dry-run"


### PR DESCRIPTION
This PR

* [x] runs `composer global require localheinz/composer-normalize:$COMPOSER_NORMALIZE_VERSION` only when the value of the `$COMPOSER_NORMALIZE_VERSION` environment variable is different from the value of the `$COMPOSER_NORMALIZE_VERSION_DEFAULT` environment variable

💁‍♂ This should speed up runs following #29.