### PR TITLE
Fix: Reduce noise when installing dependencies with composer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 ENV COMPOSER_ALLOW_SUPERUSER=1
 ENV COMPOSER_NORMALIZE_VERSION_DEFAULT=1.3.0
 
-RUN composer global require localheinz/composer-normalize:$COMPOSER_NORMALIZE_VERSION_DEFAULT
+RUN composer global require localheinz/composer-normalize:$COMPOSER_NORMALIZE_VERSION_DEFAULT --no-interaction --no-progress --no-suggest
 
 ADD entrypoint.sh /entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -l
 
 if [ -n "$COMPOSER_NORMALIZE_VERSION" ] && [ "$COMPOSER_NORMALIZE_VERSION" != "$COMPOSER_NORMALIZE_VERSION_DEFAULT" ]; then
-  composer global require localheinz/composer-normalize:"$COMPOSER_NORMALIZE_VERSION";
+  composer global require localheinz/composer-normalize:"$COMPOSER_NORMALIZE_VERSION" --no-interaction --no-progress --no-suggest;
 fi
 
 if [ "$HOME" != '/root' ]; then


### PR DESCRIPTION
This PR

* [x] reduces noise when installing dependencies with `composer`