### PR TITLE
Fix: Actually push tagged Docker image when GitHub tag is created

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,15 +26,15 @@ jobs:
         run: $(which docker) run --interactive --rm --workdir=/normalizer --volume ${GITHUB_WORKSPACE}/.build:/normalizer localheinz/composer-normalize-action:latest --indent-size=1 --indent-style=tab --no-update-lock
 
       - name: "Docker Login"
-        if: "'refs/heads/master' == github.ref || startsWith('refs/tags/', github.ref)"
+        if: "'refs/heads/master' == github.ref || startsWith(github.ref, 'refs/tags/')"
         run: echo ${{ secrets.DOCKER_PASSWORD }} | $(which docker) login --password-stdin --username ${{ secrets.DOCKER_USERNAME }}
 
       - name: "Push Docker image (latest)"
-        if: "'refs/heads/master' == github.ref || startsWith('refs/tags/', github.ref)"
+        if: "'refs/heads/master' == github.ref || startsWith(github.ref, 'refs/tags/')"
         run: $(which docker) push localheinz/composer-normalize-action:latest
 
       - name: "Push Docker image (versioned)"
-        if: "startsWith('refs/tags/', github.ref)"
+        if: "startsWith(github.ref, 'refs/tags/')"
         run: $(which docker) push localheinz/composer-normalize-action:$(bash ./.build/tag-name.sh ${GITHUB_REF})
 
       - name: "Docker Logout"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.5.0...master`](https://github.com/localheinz/composer-normalize-action/compare/0.5.0...master).
+For a full diff see [`0.5.1...master`](https://github.com/localheinz/composer-normalize-action/compare/0.5.1...master).
+
+## [`0.5.1`](https://github.com/localheinz/composer-normalize-action/releases/tag/0.5.1)
+
+For a full diff see [`0.5.0...0.5.1`](https://github.com/localheinz/composer-normalize-action/compare/0.5.0...0.5.1).
+
+### Fixed
+
+* Flipped arguments passed to `startsWith()` so Docker images are actually tagged when a tag is created on GitHub ([#49](https://github.com/localheinz/composer-normalize-action/pull/49)), by [@localheinz](https://github.com/localheinz)
 
 ## [`0.5.0`](https://github.com/localheinz/composer-normalize-action/releases/tag/0.5.0)
 
 For a full diff see [`0.4.2...0.5.0`](https://github.com/localheinz/composer-normalize-action/compare/0.4.2...0.5.0).
-
 
 ### Changed
 


### PR DESCRIPTION
This PR

* [x] flips the arguments passed to the `startsWith()` expression so a versioned Docker is tagged and pushed when a GitHub tag is created