### PR TITLE
Fix: Flip arguments

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -42,5 +42,5 @@ jobs:
         run: $(which docker) push localheinz/composer-normalize-action:$(bash ./.build/tag-name.sh ${GITHUB_REF})
 
       - name: "Docker Logout"
-        if: "'refs/heads/master' == github.ref || startsWith('refs/tags/', github.ref)"
+        if: "'refs/heads/master' == github.ref || startsWith(github.ref, 'refs/tags/')"
         run: $(which docker) logout


### PR DESCRIPTION
This PR

* [x] also flips arguments to `startsWith()` so we actually log out from Docker

Follows #49.